### PR TITLE
arch: hardened clang-tidy and standarizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ include(FetchContent)
 FetchContent_Declare(
     caffeine-hal
     GIT_REPOSITORY https://github.com/while-one/caffeine-hal.git
-    GIT_TAG        v0.5.9
+    GIT_TAG        v0.6.0
 
 )
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,6 +14,10 @@
       "inherits": "base-unit-tests-gtest"
     },
     {
+      "name": "compliance",
+      "inherits": "base-compliance"
+    },
+    {
       "name": "universe-all-sources",
       "displayName": "Universe Target (All Sources)",
       "inherits": "base-common",

--- a/include/devices/cfn_sal_accel.h
+++ b/include/devices/cfn_sal_accel.h
@@ -107,27 +107,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_accel_populate(cfn_sal_accel_t              *driver,
                                            uint32_t                      peripheral_id,
+                                           void                         *dependency,
                                            const cfn_sal_accel_api_t    *api,
                                            const cfn_sal_phy_t          *phy,
                                            const cfn_sal_accel_config_t *config,
                                            cfn_sal_accel_callback_t      callback,
                                            void                         *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_ACCEL, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_ACCEL, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_accel_construct(cfn_sal_accel_t              *driver,
                                              const cfn_sal_accel_config_t *config,
                                              const cfn_sal_phy_t          *phy,
+                                             void                         *dependency,
                                              cfn_sal_accel_callback_t      callback,
                                              void                         *user_arg);
 cfn_hal_error_code_t cfn_sal_accel_destruct(cfn_sal_accel_t *driver);

--- a/include/devices/cfn_sal_analog_sensor.h
+++ b/include/devices/cfn_sal_analog_sensor.h
@@ -58,27 +58,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_analog_sensor_populate(cfn_sal_analog_sensor_t           *driver,
                                                    uint32_t                           peripheral_id,
+                                                   void                              *dependency,
                                                    const cfn_sal_analog_sensor_api_t *api,
                                                    const cfn_sal_phy_t               *phy,
                                                    const cfn_sal_analog_config_t     *config,
                                                    cfn_sal_analog_callback_t          callback,
                                                    void                              *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_ANALOG_SENSOR, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_ANALOG_SENSOR, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_analog_sensor_construct(cfn_sal_analog_sensor_t       *driver,
                                                      const cfn_sal_analog_config_t *config,
                                                      const cfn_sal_phy_t           *phy,
+                                                     void                          *dependency,
                                                      cfn_sal_analog_callback_t      callback,
                                                      void                          *user_arg);
 cfn_hal_error_code_t cfn_sal_analog_sensor_destruct(cfn_sal_analog_sensor_t *driver);

--- a/include/devices/cfn_sal_battery.h
+++ b/include/devices/cfn_sal_battery.h
@@ -94,27 +94,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_battery_populate(cfn_sal_battery_t              *driver,
                                              uint32_t                        peripheral_id,
+                                             void                           *dependency,
                                              const cfn_sal_battery_api_t    *api,
                                              const cfn_sal_phy_t            *phy,
                                              const cfn_sal_battery_config_t *config,
                                              cfn_sal_battery_callback_t      callback,
                                              void                           *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_BATTERY, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_BATTERY, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_battery_construct(cfn_sal_battery_t              *driver,
                                                const cfn_sal_battery_config_t *config,
                                                const cfn_sal_phy_t            *phy,
+                                               void                           *dependency,
                                                cfn_sal_battery_callback_t      callback,
                                                void                           *user_arg);
 cfn_hal_error_code_t cfn_sal_battery_destruct(cfn_sal_battery_t *driver);

--- a/include/devices/cfn_sal_button.h
+++ b/include/devices/cfn_sal_button.h
@@ -81,27 +81,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_button_populate(cfn_sal_button_t              *driver,
                                             uint32_t                       peripheral_id,
+                                            void                          *dependency,
                                             const cfn_sal_button_api_t    *api,
                                             const cfn_sal_phy_t           *phy,
                                             const cfn_sal_button_config_t *config,
                                             cfn_sal_button_callback_t      callback,
                                             void                          *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_BUTTON, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_BUTTON, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_button_construct(cfn_sal_button_t              *driver,
                                               const cfn_sal_button_config_t *config,
                                               const cfn_sal_phy_t           *phy,
+                                              void                          *dependency,
                                               cfn_sal_button_callback_t      callback,
                                               void                          *user_arg);
 cfn_hal_error_code_t cfn_sal_button_destruct(cfn_sal_button_t *driver);

--- a/include/devices/cfn_sal_color_sensor.h
+++ b/include/devices/cfn_sal_color_sensor.h
@@ -73,27 +73,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_color_sensor_populate(cfn_sal_color_sensor_t           *driver,
                                                   uint32_t                          peripheral_id,
+                                                  void                             *dependency,
                                                   const cfn_sal_color_sensor_api_t *api,
                                                   const cfn_sal_phy_t              *phy,
                                                   const cfn_sal_color_config_t     *config,
                                                   cfn_sal_color_callback_t          callback,
                                                   void                             *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_COLOR_SENSOR, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_COLOR_SENSOR, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_color_sensor_construct(cfn_sal_color_sensor_t       *driver,
                                                     const cfn_sal_color_config_t *config,
                                                     const cfn_sal_phy_t          *phy,
+                                                    void                         *dependency,
                                                     cfn_sal_color_callback_t      callback,
                                                     void                         *user_arg);
 cfn_hal_error_code_t cfn_sal_color_sensor_destruct(cfn_sal_color_sensor_t *driver);

--- a/include/devices/cfn_sal_display.h
+++ b/include/devices/cfn_sal_display.h
@@ -88,27 +88,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_display_populate(cfn_sal_display_t              *driver,
                                              uint32_t                        peripheral_id,
+                                             void                           *dependency,
                                              const cfn_sal_display_api_t    *api,
                                              const cfn_sal_phy_t            *phy,
                                              const cfn_sal_display_config_t *config,
                                              cfn_sal_display_callback_t      callback,
                                              void                           *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_DISPLAY, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_DISPLAY, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_display_construct(cfn_sal_display_t              *driver,
                                                const cfn_sal_display_config_t *config,
                                                const cfn_sal_phy_t            *phy,
+                                               void                           *dependency,
                                                cfn_sal_display_callback_t      callback,
                                                void                           *user_arg);
 cfn_hal_error_code_t cfn_sal_display_destruct(cfn_sal_display_t *driver);

--- a/include/devices/cfn_sal_gnss.h
+++ b/include/devices/cfn_sal_gnss.h
@@ -103,27 +103,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(sal_gnss, cfn_sal_gnss_config_t, cfn_sal_gnss_api_t, 
 
 CFN_HAL_INLINE void cfn_sal_gnss_populate(cfn_sal_gnss_t              *driver,
                                           uint32_t                     peripheral_id,
+                                          void                        *dependency,
                                           const cfn_sal_gnss_api_t    *api,
                                           const cfn_sal_phy_t         *phy,
                                           const cfn_sal_gnss_config_t *config,
                                           cfn_sal_gnss_callback_t      callback,
                                           void                        *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_GNSS, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_GNSS, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_gnss_construct(cfn_sal_gnss_t              *driver,
                                             const cfn_sal_gnss_config_t *config,
                                             const cfn_sal_phy_t         *phy,
+                                            void                        *dependency,
                                             cfn_sal_gnss_callback_t      callback,
                                             void                        *user_arg);
 cfn_hal_error_code_t cfn_sal_gnss_destruct(cfn_sal_gnss_t *driver);

--- a/include/devices/cfn_sal_gsm.h
+++ b/include/devices/cfn_sal_gsm.h
@@ -100,27 +100,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(sal_gsm, cfn_sal_gsm_config_t, cfn_sal_gsm_api_t, cfn
 
 CFN_HAL_INLINE void cfn_sal_gsm_populate(cfn_sal_gsm_t              *driver,
                                          uint32_t                    peripheral_id,
+                                         void                       *dependency,
                                          const cfn_sal_gsm_api_t    *api,
                                          const cfn_sal_phy_t        *phy,
                                          const cfn_sal_gsm_config_t *config,
                                          cfn_sal_gsm_callback_t      callback,
                                          void                       *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_GSM, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_GSM, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_gsm_construct(cfn_sal_gsm_t              *driver,
                                            const cfn_sal_gsm_config_t *config,
                                            const cfn_sal_phy_t        *phy,
+                                           void                       *dependency,
                                            cfn_sal_gsm_callback_t      callback,
                                            void                       *user_arg);
 cfn_hal_error_code_t cfn_sal_gsm_destruct(cfn_sal_gsm_t *driver);

--- a/include/devices/cfn_sal_gyro_sensor.h
+++ b/include/devices/cfn_sal_gyro_sensor.h
@@ -99,27 +99,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_gyro_sensor_populate(cfn_sal_gyro_sensor_t           *driver,
                                                  uint32_t                         peripheral_id,
+                                                 void                            *dependency,
                                                  const cfn_sal_gyro_sensor_api_t *api,
                                                  const cfn_sal_phy_t             *phy,
                                                  const cfn_sal_gyro_config_t     *config,
                                                  cfn_sal_gyro_callback_t          callback,
                                                  void                            *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_GYRO_SENSOR, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_GYRO_SENSOR, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_gyro_sensor_construct(cfn_sal_gyro_sensor_t       *driver,
                                                    const cfn_sal_gyro_config_t *config,
                                                    const cfn_sal_phy_t         *phy,
+                                                   void                        *dependency,
                                                    cfn_sal_gyro_callback_t      callback,
                                                    void                        *user_arg);
 cfn_hal_error_code_t cfn_sal_gyro_sensor_destruct(cfn_sal_gyro_sensor_t *driver);

--- a/include/devices/cfn_sal_hum_sensor.h
+++ b/include/devices/cfn_sal_hum_sensor.h
@@ -79,27 +79,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_hum_sensor_populate(cfn_sal_hum_sensor_t           *driver,
                                                 uint32_t                        peripheral_id,
+                                                void                           *dependency,
                                                 const cfn_sal_hum_sensor_api_t *api,
                                                 const cfn_sal_phy_t            *phy,
                                                 const cfn_sal_hum_config_t     *config,
                                                 cfn_sal_hum_callback_t          callback,
                                                 void                           *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_HUM_SENSOR, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_HUM_SENSOR, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_hum_sensor_construct(cfn_sal_hum_sensor_t       *driver,
                                                   const cfn_sal_hum_config_t *config,
                                                   const cfn_sal_phy_t        *phy,
+                                                  void                       *dependency,
                                                   cfn_sal_hum_callback_t      callback,
                                                   void                       *user_arg);
 cfn_hal_error_code_t cfn_sal_hum_sensor_destruct(cfn_sal_hum_sensor_t *driver);

--- a/include/devices/cfn_sal_led.h
+++ b/include/devices/cfn_sal_led.h
@@ -79,27 +79,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(sal_led, cfn_sal_led_config_t, cfn_sal_led_api_t, cfn
 
 CFN_HAL_INLINE void cfn_sal_led_populate(cfn_sal_led_t              *driver,
                                          uint32_t                    peripheral_id,
+                                         void                       *dependency,
                                          const cfn_sal_led_api_t    *api,
                                          const cfn_sal_phy_t        *phy,
                                          const cfn_sal_led_config_t *config,
                                          cfn_sal_led_callback_t      callback,
                                          void                       *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_LED, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_LED, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_led_construct(cfn_sal_led_t              *driver,
                                            const cfn_sal_led_config_t *config,
                                            const cfn_sal_phy_t        *phy,
+                                           void                       *dependency,
                                            cfn_sal_led_callback_t      callback,
                                            void                       *user_arg);
 cfn_hal_error_code_t cfn_sal_led_destruct(cfn_sal_led_t *driver);

--- a/include/devices/cfn_sal_light_sensor.h
+++ b/include/devices/cfn_sal_light_sensor.h
@@ -72,27 +72,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_light_sensor_populate(cfn_sal_light_sensor_t           *driver,
                                                   uint32_t                          peripheral_id,
+                                                  void                             *dependency,
                                                   const cfn_sal_light_sensor_api_t *api,
                                                   const cfn_sal_phy_t              *phy,
                                                   const cfn_sal_light_config_t     *config,
                                                   cfn_sal_light_callback_t          callback,
                                                   void                             *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_LIGHT_SENSOR, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_LIGHT_SENSOR, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_light_sensor_construct(cfn_sal_light_sensor_t       *driver,
                                                     const cfn_sal_light_config_t *config,
                                                     const cfn_sal_phy_t          *phy,
+                                                    void                         *dependency,
                                                     cfn_sal_light_callback_t      callback,
                                                     void                         *user_arg);
 cfn_hal_error_code_t cfn_sal_light_sensor_destruct(cfn_sal_light_sensor_t *driver);

--- a/include/devices/cfn_sal_mag_sensor.h
+++ b/include/devices/cfn_sal_mag_sensor.h
@@ -92,23 +92,24 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_mag_sensor_populate(cfn_sal_mag_sensor_t           *driver,
                                                 uint32_t                        peripheral_id,
+                                                void                           *dependency,
                                                 const cfn_sal_mag_sensor_api_t *api,
                                                 const cfn_sal_phy_t            *phy,
                                                 const cfn_sal_mag_config_t     *config,
                                                 cfn_sal_mag_callback_t          callback,
                                                 void                           *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_MAG_SENSOR, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_MAG_SENSOR, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
+
+cfn_hal_error_code_t cfn_sal_mag_sensor_construct(cfn_sal_mag_sensor_t       *driver,
+                                                  const cfn_sal_mag_config_t *config,
+                                                  const cfn_sal_phy_t        *phy,
+                                                  void                       *dependency,
+                                                  cfn_sal_mag_callback_t      callback,
+                                                  void                       *user_arg);
+cfn_hal_error_code_t cfn_sal_mag_sensor_destruct(cfn_sal_mag_sensor_t *driver);
 
 CFN_HAL_INLINE cfn_hal_error_code_t cfn_sal_mag_sensor_init(cfn_sal_mag_sensor_t *driver)
 {

--- a/include/devices/cfn_sal_pressure_sensor.h
+++ b/include/devices/cfn_sal_pressure_sensor.h
@@ -82,27 +82,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(sal_pressure_sensor,
 
 CFN_HAL_INLINE void cfn_sal_pressure_sensor_populate(cfn_sal_pressure_sensor_t           *driver,
                                                      uint32_t                             peripheral_id,
+                                                     void                                *dependency,
                                                      const cfn_sal_pressure_sensor_api_t *api,
                                                      const cfn_sal_phy_t                 *phy,
                                                      const cfn_sal_pressure_config_t     *config,
                                                      cfn_sal_pressure_callback_t          callback,
                                                      void                                *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_PRESSURE_SENSOR, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_PRESSURE_SENSOR, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_pressure_sensor_construct(cfn_sal_pressure_sensor_t       *driver,
                                                        const cfn_sal_pressure_config_t *config,
                                                        const cfn_sal_phy_t             *phy,
+                                                       void                            *dependency,
                                                        cfn_sal_pressure_callback_t      callback,
                                                        void                            *user_arg);
 cfn_hal_error_code_t cfn_sal_pressure_sensor_destruct(cfn_sal_pressure_sensor_t *driver);

--- a/include/devices/cfn_sal_prox_sensor.h
+++ b/include/devices/cfn_sal_prox_sensor.h
@@ -72,27 +72,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_prox_sensor_populate(cfn_sal_prox_sensor_t           *driver,
                                                  uint32_t                         peripheral_id,
+                                                 void                            *dependency,
                                                  const cfn_sal_prox_sensor_api_t *api,
                                                  const cfn_sal_phy_t             *phy,
                                                  const cfn_sal_prox_config_t     *config,
                                                  cfn_sal_prox_callback_t          callback,
                                                  void                            *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_PROX_SENSOR, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_PROX_SENSOR, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_prox_sensor_construct(cfn_sal_prox_sensor_t       *driver,
                                                    const cfn_sal_prox_config_t *config,
                                                    const cfn_sal_phy_t         *phy,
+                                                   void                        *dependency,
                                                    cfn_sal_prox_callback_t      callback,
                                                    void                        *user_arg);
 cfn_hal_error_code_t cfn_sal_prox_sensor_destruct(cfn_sal_prox_sensor_t *driver);

--- a/include/devices/cfn_sal_temp_sensor.h
+++ b/include/devices/cfn_sal_temp_sensor.h
@@ -85,27 +85,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_temp_sensor_populate(cfn_sal_temp_sensor_t           *driver,
                                                  uint32_t                         peripheral_id,
+                                                 void                            *dependency,
                                                  const cfn_sal_temp_sensor_api_t *api,
                                                  const cfn_sal_phy_t             *phy,
                                                  const cfn_sal_temp_config_t     *config,
                                                  cfn_sal_temp_callback_t          callback,
                                                  void                            *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_TEMP_SENSOR, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_TEMP_SENSOR, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_temp_sensor_construct(cfn_sal_temp_sensor_t       *driver,
                                                    const cfn_sal_temp_config_t *config,
                                                    const cfn_sal_phy_t         *phy,
+                                                   void                        *dependency,
                                                    cfn_sal_temp_callback_t      callback,
                                                    void                        *user_arg);
 cfn_hal_error_code_t cfn_sal_temp_sensor_destruct(cfn_sal_temp_sensor_t *driver);

--- a/include/network/cfn_sal_connection.h
+++ b/include/network/cfn_sal_connection.h
@@ -99,27 +99,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(sal_connection,
 
 CFN_HAL_INLINE void cfn_sal_connection_populate(cfn_sal_connection_t              *driver,
                                                 uint32_t                           peripheral_id,
+                                                void                              *dependency,
                                                 const cfn_sal_connection_api_t    *api,
                                                 const cfn_sal_phy_t               *phy,
                                                 const cfn_sal_connection_config_t *config,
                                                 cfn_sal_connection_callback_t      callback,
                                                 void                              *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_CONNECTION, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_CONNECTION, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_connection_construct(cfn_sal_connection_t              *driver,
                                                   const cfn_sal_connection_config_t *config,
                                                   const cfn_sal_phy_t               *phy,
+                                                  void                              *dependency,
                                                   cfn_sal_connection_callback_t      callback,
                                                   void                              *user_arg);
 cfn_hal_error_code_t cfn_sal_connection_destruct(cfn_sal_connection_t *driver);

--- a/include/network/cfn_sal_transport.h
+++ b/include/network/cfn_sal_transport.h
@@ -82,27 +82,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_transport_populate(cfn_sal_transport_t              *driver,
                                                uint32_t                          peripheral_id,
+                                               void                             *dependency,
                                                const cfn_sal_transport_api_t    *api,
                                                const cfn_sal_phy_t              *phy,
                                                const cfn_sal_transport_config_t *config,
                                                cfn_sal_transport_callback_t      callback,
                                                void                             *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_TRANSPORT, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_TRANSPORT, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_transport_construct(cfn_sal_transport_t              *driver,
                                                  const cfn_sal_transport_config_t *config,
                                                  const cfn_sal_phy_t              *phy,
+                                                 void                             *dependency,
                                                  cfn_sal_transport_callback_t      callback,
                                                  void                             *user_arg);
 cfn_hal_error_code_t cfn_sal_transport_destruct(cfn_sal_transport_t *driver);

--- a/include/utilities/cfn_sal_at_parser.h
+++ b/include/utilities/cfn_sal_at_parser.h
@@ -82,27 +82,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_at_parser_populate(cfn_sal_at_parser_t           *driver,
                                                uint32_t                       peripheral_id,
+                                               void                          *dependency,
                                                const cfn_sal_at_parser_api_t *api,
                                                const cfn_sal_phy_t           *phy,
                                                const cfn_sal_at_config_t     *config,
                                                cfn_hal_callback_t             callback,
                                                void                          *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_AT_PARSER, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_AT_PARSER, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_at_parser_construct(cfn_sal_at_parser_t       *driver,
                                                  const cfn_sal_at_config_t *config,
                                                  const cfn_sal_phy_t       *phy,
+                                                 void                      *dependency,
                                                  cfn_hal_callback_t         callback,
                                                  void                      *user_arg);
 cfn_hal_error_code_t cfn_sal_at_parser_destruct(cfn_sal_at_parser_t *driver);

--- a/include/utilities/cfn_sal_cli.h
+++ b/include/utilities/cfn_sal_cli.h
@@ -84,27 +84,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(sal_cli, cfn_sal_cli_config_t, cfn_sal_cli_api_t, cfn
 
 CFN_HAL_INLINE void cfn_sal_cli_populate(cfn_sal_cli_t              *driver,
                                          uint32_t                    peripheral_id,
+                                         void                       *dependency,
                                          const cfn_sal_cli_api_t    *api,
                                          const cfn_sal_phy_t        *phy,
                                          const cfn_sal_cli_config_t *config,
                                          cfn_sal_cli_callback_t      callback,
                                          void                       *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_CLI, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_CLI, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_cli_construct(cfn_sal_cli_t              *driver,
                                            const cfn_sal_cli_config_t *config,
                                            const cfn_sal_phy_t        *phy,
+                                           void                       *dependency,
                                            cfn_sal_cli_callback_t      callback,
                                            void                       *user_arg);
 cfn_hal_error_code_t cfn_sal_cli_destruct(cfn_sal_cli_t *driver);

--- a/include/utilities/cfn_sal_collection.h
+++ b/include/utilities/cfn_sal_collection.h
@@ -89,27 +89,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(sal_collection,
 
 CFN_HAL_INLINE void cfn_sal_collection_populate(cfn_sal_collection_t              *driver,
                                                 uint32_t                           peripheral_id,
+                                                void                              *dependency,
                                                 const cfn_sal_collection_api_t    *api,
                                                 const cfn_sal_phy_t               *phy,
                                                 const cfn_sal_collection_config_t *config,
                                                 cfn_sal_collection_callback_t      callback,
                                                 void                              *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_COLLECTION, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_COLLECTION, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_collection_construct(cfn_sal_collection_t              *driver,
                                                   const cfn_sal_collection_config_t *config,
                                                   const cfn_sal_phy_t               *phy,
+                                                  void                              *dependency,
                                                   cfn_sal_collection_callback_t      callback,
                                                   void                              *user_arg);
 cfn_hal_error_code_t cfn_sal_collection_destruct(cfn_sal_collection_t *driver);

--- a/include/utilities/cfn_sal_fs.h
+++ b/include/utilities/cfn_sal_fs.h
@@ -90,27 +90,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(sal_fs, cfn_sal_fs_config_t, cfn_sal_fs_api_t, cfn_sa
 
 CFN_HAL_INLINE void cfn_sal_fs_populate(cfn_sal_fs_t              *driver,
                                         uint32_t                   peripheral_id,
+                                        void                      *dependency,
                                         const cfn_sal_fs_api_t    *api,
                                         const cfn_sal_phy_t       *phy,
                                         const cfn_sal_fs_config_t *config,
                                         cfn_sal_fs_callback_t      callback,
                                         void                      *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_FS, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_FS, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_fs_construct(cfn_sal_fs_t              *driver,
                                           const cfn_sal_fs_config_t *config,
                                           const cfn_sal_phy_t       *phy,
+                                          void                      *dependency,
                                           cfn_sal_fs_callback_t      callback,
                                           void                      *user_arg);
 cfn_hal_error_code_t cfn_sal_fs_destruct(cfn_sal_fs_t *driver);

--- a/include/utilities/cfn_sal_kv.h
+++ b/include/utilities/cfn_sal_kv.h
@@ -57,27 +57,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(sal_kv, cfn_sal_kv_config_t, cfn_sal_kv_api_t, cfn_sa
 
 CFN_HAL_INLINE void cfn_sal_kv_populate(cfn_sal_kv_t              *driver,
                                         uint32_t                   peripheral_id,
+                                        void                      *dependency,
                                         const cfn_sal_kv_api_t    *api,
                                         const cfn_sal_phy_t       *phy,
                                         const cfn_sal_kv_config_t *config,
                                         cfn_sal_kv_callback_t      callback,
                                         void                      *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_KV, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_KV, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_kv_construct(cfn_sal_kv_t              *driver,
                                           const cfn_sal_kv_config_t *config,
                                           const cfn_sal_phy_t       *phy,
+                                          void                      *dependency,
                                           cfn_sal_kv_callback_t      callback,
                                           void                      *user_arg);
 cfn_hal_error_code_t cfn_sal_kv_destruct(cfn_sal_kv_t *driver);

--- a/include/utilities/cfn_sal_logging.h
+++ b/include/utilities/cfn_sal_logging.h
@@ -84,27 +84,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(
 
 CFN_HAL_INLINE void cfn_sal_logging_populate(cfn_sal_logging_t              *driver,
                                              uint32_t                        peripheral_id,
+                                             void                           *dependency,
                                              const cfn_sal_logging_api_t    *api,
                                              const cfn_sal_phy_t            *phy,
                                              const cfn_sal_logging_config_t *config,
                                              cfn_sal_logging_callback_t      callback,
                                              void                           *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_LOGGING, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_LOGGING, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_logging_construct(cfn_sal_logging_t              *driver,
                                                const cfn_sal_logging_config_t *config,
                                                const cfn_sal_phy_t            *phy,
+                                               void                           *dependency,
                                                cfn_sal_logging_callback_t      callback,
                                                void                           *user_arg);
 cfn_hal_error_code_t cfn_sal_logging_destruct(cfn_sal_logging_t *driver);

--- a/include/utilities/cfn_sal_serialization.h
+++ b/include/utilities/cfn_sal_serialization.h
@@ -147,27 +147,21 @@ typedef struct cfn_sal_serialization_s cfn_sal_serialization_t;
 
 CFN_HAL_INLINE void cfn_sal_serialization_populate(cfn_sal_serialization_t              *driver,
                                                    uint32_t                              peripheral_id,
+                                                   void                                 *dependency,
                                                    const cfn_sal_serialization_api_t    *api,
                                                    const cfn_sal_phy_t                  *phy,
                                                    const cfn_sal_serialization_config_t *config,
                                                    cfn_sal_serialization_callback_t      callback,
                                                    void                                 *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_SERIALIZATION, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_SERIALIZATION, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_serialization_construct(cfn_sal_serialization_t              *driver,
                                                      const cfn_sal_serialization_config_t *config,
                                                      const cfn_sal_phy_t                  *phy,
+                                                     void                                 *dependency,
                                                      cfn_sal_serialization_callback_t      callback,
                                                      void                                 *user_arg);
 

--- a/include/utilities/cfn_sal_timekeeping.h
+++ b/include/utilities/cfn_sal_timekeeping.h
@@ -74,27 +74,21 @@ CFN_SAL_CREATE_DRIVER_TYPE(sal_timekeeping,
 
 CFN_HAL_INLINE void cfn_sal_timekeeping_populate(cfn_sal_timekeeping_t              *driver,
                                                  uint32_t                            peripheral_id,
+                                                 void                               *dependency,
                                                  const cfn_sal_timekeeping_api_t    *api,
                                                  const cfn_sal_phy_t                *phy,
                                                  const cfn_sal_timekeeping_config_t *config,
                                                  cfn_sal_timekeeping_callback_t      callback,
                                                  void                               *user_arg)
 {
-    if (!driver)
-    {
-        return;
-    }
-    cfn_hal_base_populate(&driver->base, CFN_SAL_TYPE_TIMEKEEPING, peripheral_id, api ? &api->base : NULL, NULL);
-    driver->api         = api;
-    driver->phy         = phy;
-    driver->config      = config;
-    driver->cb          = callback;
-    driver->cb_user_arg = user_arg;
+    CFN_HAL_POPULATE_DRIVER(
+        driver, CFN_SAL_TYPE_TIMEKEEPING, peripheral_id, NULL, dependency, api, phy, config, callback, user_arg);
 }
 
 cfn_hal_error_code_t cfn_sal_timekeeping_construct(cfn_sal_timekeeping_t              *driver,
                                                    const cfn_sal_timekeeping_config_t *config,
                                                    const cfn_sal_phy_t                *phy,
+                                                   void                               *dependency,
                                                    cfn_sal_timekeeping_callback_t      callback,
                                                    void                               *user_arg);
 cfn_hal_error_code_t cfn_sal_timekeeping_destruct(cfn_sal_timekeeping_t *driver);

--- a/tests/cfn_sal_test_foundation.cpp
+++ b/tests/cfn_sal_test_foundation.cpp
@@ -24,6 +24,7 @@ CFN_SAL_CREATE_DRIVER_TYPE(dummy_sal, dummy_sal_config_t, struct dummy_sal_api_s
 
 CFN_HAL_INLINE void cfn_dummy_sal_populate(cfn_dummy_sal_t              *driver,
                                            uint32_t                      peripheral_id,
+                                           void                         *dependency,
                                            const struct dummy_sal_api_s *api,
                                            const cfn_sal_phy_t          *phy,
                                            const dummy_sal_config_t     *config,
@@ -34,7 +35,8 @@ CFN_HAL_INLINE void cfn_dummy_sal_populate(cfn_dummy_sal_t              *driver,
     {
         return;
     }
-    cfn_hal_base_populate(&driver->base, peripheral_id, peripheral_id, api ? &api->base : NULL, NULL);
+    cfn_hal_base_populate(
+        &driver->base, CFN_SAL_TYPE('D', 'U', 'M'), peripheral_id, api ? &api->base : NULL, NULL, dependency);
     driver->api         = api;
     driver->phy         = phy;
     driver->config      = config;
@@ -59,7 +61,7 @@ TEST(FoundationTest, DriverPopulate)
     dummy_sal_config_t     config = {};
 
     cfn_dummy_sal_t driver{};
-    cfn_dummy_sal_populate(&driver, CFN_SAL_TYPE('D', 'U', 'M'), &api, &phy, &config, NULL, NULL);
+    cfn_dummy_sal_populate(&driver, CFN_SAL_TYPE('D', 'U', 'M'), NULL, &api, &phy, &config, NULL, NULL);
 
     EXPECT_EQ(driver.base.type, CFN_SAL_TYPE('D', 'U', 'M'));
     EXPECT_EQ(driver.base.status, CFN_HAL_DRIVER_STATUS_CONSTRUCTED);

--- a/tests/compliance.c
+++ b/tests/compliance.c
@@ -65,7 +65,7 @@ int main(void)
     /* 1. Test Static Initializer Macros */
     cfn_sal_led_t led = { 0 };
 
-    cfn_sal_led_populate(&led, 0xDEAD, &DUMMY_LED_API, &LED_PHY, &LED_CONFIG, NULL, NULL);
+    cfn_sal_led_populate(&led, 0xDEAD, NULL, &DUMMY_LED_API, &LED_PHY, &LED_CONFIG, NULL, NULL);
     /* 2. Test Base Initialization (Macro Expansion) */
     cfn_hal_error_code_t err = cfn_sal_led_init(&led);
     if (err != CFN_HAL_ERROR_OK)


### PR DESCRIPTION
- Hardened the rules in clang-tidy
- Refactor _construct and _populate signatures to include void* dependency.
- Enforce parameter ordering: clock -> dependency -> callback.
- Introduce CFN_HAL_POPULATE_DRIVER macro for consistent field assignment.
- Standardize peripheral destructors to utilize _populate for safe cleanup.
- Refactor STM32F4 port mappings to O(1) table-driven lookups.
- Align STM32F4 module names with vendor HAL configuration templates.
- Fix UART/USART registration to ensure dual module enablement.
 - Enhance build.sh with unbuffered full-line colorization.
 - Implement CI summaries and robust failure detection using PIPESTATUS.
 - Optimize ci.sh to skip static analysis for unit test presets.

## Description
<!-- Provide a brief summary of the changes and the reasoning behind them. -->

## Type of Change
<!-- Please check the options that are relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the project style (run `make format` locally)
- [ ] I have run static analysis (`make analyze`) and fixed any warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Version Bump
<!-- Select one. This will automate the SemVer update in CMakeLists.txt upon merge. -->
- [ ] major
- [ ] minor
- [x] patch
