### PR TITLE
standardize SAL composite sensor architecture and nomenclature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ target_link_libraries(${PROJECT_NAME} INTERFACE caffeine::hal)
 
 # Gather all headers for target definition and tooling
 # Actual binary targets MUST explicitly list all sources for determinism
-set(PROJECT_ALL_HEADERS
+set(CFN_SAL_SOURCES_H
     include/cfn_sal.h
     include/cfn_sal_types.h
     include/devices/cfn_sal_accel.h
@@ -66,6 +66,7 @@ set(PROJECT_ALL_HEADERS
     include/devices/cfn_sal_battery.h
     include/devices/cfn_sal_button.h
     include/devices/cfn_sal_color_sensor.h
+    include/devices/cfn_sal_composite.h
     include/devices/cfn_sal_display.h
     include/devices/cfn_sal_gnss.h
     include/devices/cfn_sal_gsm.h
@@ -95,7 +96,7 @@ target_sources(
         FILE_SET headers
         TYPE HEADERS
         BASE_DIRS include
-        FILES ${PROJECT_ALL_HEADERS}
+        FILES ${CFN_SAL_SOURCES_H}
 )
 
 # --- Testing ---

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The library decouples high-level application logic from concrete implementations
 *   `caffeine-build/`: Submodule containing centralized build presets, toolchains, scripts, and hardware target definitions.
 *   `include/cfn_sal.h`: Core macros and FourCC definitions.
 *   `include/devices/`: Hardware-agnostic interfaces for physical components.
-    *   `led.h`, `button.h`, `accel.h`, `temp_sensor.h`, `hum_sensor.h`, `battery.h`, `light_sensor.h`, `pressure_sensor.h`, `gnss.h`, `display.h`.
+    *   `led.h`, `button.h`, `accel.h`, `temp_sensor.h`, `hum_sensor.h`, `battery.h`, `light_sensor.h`, `pressure_sensor.h`, `gnss.h`, `display.h`, `composite.h`.
 *   `include/network/`: Generic connectivity and protocol abstractions.
     *   `connection.h` (Link-layer management), `transport.h` (Streaming/Datagram Data).
 *   `include/utilities/`: High-level software services and data structures.

--- a/include/cfn_sal.h
+++ b/include/cfn_sal.h
@@ -53,19 +53,6 @@ extern "C"
 
 /* Types Structs ----------------------------------------------------*/
 
-/**
- * @brief Standardized shared state for combination sensors.
- * This structure should be embedded within a composite sensor struct
- * to manage shared hardware resources and initialization counts across
- * multiple polymorphic interfaces.
- */
-typedef struct
-{
-    const cfn_sal_phy_t *phy;            /*!< Shared physical interface handle */
-    uint8_t              init_ref_count; /*!< Number of active interfaces using this PHY */
-    bool                 hw_initialized; /*!< Flag indicating if physical hardware is ready */
-} cfn_sal_combined_state_t;
-
 /* Functions prototypes ---------------------------------------------*/
 
 #ifdef __cplusplus

--- a/include/devices/cfn_sal_composite.h
+++ b/include/devices/cfn_sal_composite.h
@@ -1,0 +1,79 @@
+/**
+ * @file cfn_sal_composite.h
+ * @brief Standardized shared state for composite (multi-function) sensors.
+ */
+
+#ifndef CAFFEINE_SAL_DEVICES_CFN_SAL_COMPOSITE_H
+#define CAFFEINE_SAL_DEVICES_CFN_SAL_COMPOSITE_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Includes ---------------------------------------------------------*/
+#include "cfn_sal.h"
+
+/* Types Structs ----------------------------------------------------*/
+
+/**
+ * @brief Standardized shared state for composite (multi-function) sensors.
+ * This structure should be embedded within a composite sensor struct
+ * to manage shared hardware resources and initialization counts across
+ * multiple polymorphic interfaces.
+ */
+typedef struct
+{
+    const cfn_sal_phy_t *phy;            /*!< Shared physical interface handle */
+    uint8_t              init_ref_count; /*!< Number of active interfaces using this PHY */
+    bool                 hw_initialized; /*!< Flag indicating if physical hardware is ready */
+} cfn_sal_composite_shared_t;
+
+/* Functions inline ------------------------------------------------- */
+
+/**
+ * @brief Initialize the shared composite state.
+ *
+ * @param state Pointer to the shared state structure.
+ * @param phy   Pointer to the shared physical interface mapping.
+ * @return CFN_HAL_ERROR_OK on success.
+ */
+CFN_HAL_INLINE cfn_hal_error_code_t cfn_sal_composite_init(cfn_sal_composite_shared_t *state, const cfn_sal_phy_t *phy)
+{
+    if ((state == NULL) || (phy == NULL))
+    {
+        return CFN_HAL_ERROR_BAD_PARAM;
+    }
+
+    state->phy            = phy;
+    state->init_ref_count = 0;
+    state->hw_initialized = false;
+
+    return CFN_HAL_ERROR_OK;
+}
+
+/**
+ * @brief Deinitialize the shared composite state.
+ *
+ * @param state Pointer to the shared state structure.
+ * @return CFN_HAL_ERROR_OK on success.
+ */
+CFN_HAL_INLINE cfn_hal_error_code_t cfn_sal_composite_deinit(cfn_sal_composite_shared_t *state)
+{
+    if (state == NULL)
+    {
+        return CFN_HAL_ERROR_BAD_PARAM;
+    }
+
+    state->phy            = NULL;
+    state->init_ref_count = 0;
+    state->hw_initialized = false;
+
+    return CFN_HAL_ERROR_OK;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CAFFEINE_SAL_DEVICES_CFN_SAL_COMPOSITE_H */


### PR DESCRIPTION
- Create cfn_sal_composite.h with standardized shared state and lifecycle helpers.
- Rename 'combined_sensor' to 'composite_sensor' for architectural consistency.
- Refactor composite sensors (BME280, SHT40, etc.) to use strict interface naming (temp, hum, accel, etc.).
- Implement explicit, type-safe static inline getters for all composite sensor interfaces.
- Standardize constructor signatures across single and composite sensors to include dependency pointers.
- Rename CMake source variables to CFN_SAL_SOURCES and CFN_SAL_IMPL_SOURCES.
- Update unit tests and documentation to reflect the new standards.

## Description
<!-- Provide a brief summary of the changes and the reasoning behind them. -->

## Type of Change
<!-- Please check the options that are relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the project style (run `make format` locally)
- [ ] I have run static analysis (`make analyze`) and fixed any warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Version Bump
<!-- Select one. This will automate the SemVer update in CMakeLists.txt upon merge. -->
- [ ] major
- [ ] minor
- [x] patch
